### PR TITLE
Promo Tax Fix

### DIFF
--- a/spree_avatax_certified.gemspec
+++ b/spree_avatax_certified.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_avatax_certified'
-  s.version     = '0.3.9'
+  s.version     = '0.3.10'
   s.summary     = 'Spree extension for Avalara tax calculation.'
   s.description = 'Spree extension for Avalara tax calculation.'
   s.required_ruby_version = '>= 1.9.3'


### PR DESCRIPTION
This takes whole order discounts into consideration when sending to Avalara. It will distribute that discount evenly across all line items. This affects any whole order discount promotion and Platinum Points applications. Individual line item discounts should only be taxed at their discounted rates and this should not apply to them unless there is a whole order discount in addition to the line item discounts.
