### PR TITLE
Only do discounts on eligible adjustments

### DIFF
--- a/app/models/spree/avalara_transaction.rb
+++ b/app/models/spree/avalara_transaction.rb
@@ -148,7 +148,7 @@ module Spree
         AVALARA_TRANSACTION_LOGGER.debug "error with order's user id"
       end
 
-      discount = order_details.adjustments.promotion.sum(:amount) * -1  # Discounts are negative and Avalara wants positive discount
+      discount = order_details.adjustments.eligible.promotion.sum(:amount) * -1  # Discounts are negative and Avalara wants positive discount
 
       i = 0
 

--- a/spree_avatax_certified.gemspec
+++ b/spree_avatax_certified.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_avatax_certified'
-  s.version     = '0.3.10'
+  s.version     = '0.3.11'
   s.summary     = 'Spree extension for Avalara tax calculation.'
   s.description = 'Spree extension for Avalara tax calculation.'
   s.required_ruby_version = '>= 1.9.3'


### PR DESCRIPTION
We were sending all adjustments to Avalara even if they were not eligible for the order. This fixes that.
